### PR TITLE
Added imageTag parameter to AddClickhouse method

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ var api = builder.AddProject<Projects.ClickHouse_DemoApi>("api")
        .WithReference(db);
 ```
 
+## Optional Parameters
+When using the `AddClickHouse` method, you can specify the following optional parameters:
+
+| Parameter | Description | Default Value |
+|-----------|-------------|---------------|
+| `userName` | Username for ClickHouse authentication | - |
+| `password` | Password for ClickHouse authentication | - |
+| `port` | Port number for ClickHouse container | 8123 |
+| `imageTag` | Version tag of ClickHouse server image | "25.6" |
+
 
 ## Feedback & contributing
 

--- a/playground/ClickHouse.AppHost/Program.cs
+++ b/playground/ClickHouse.AppHost/Program.cs
@@ -1,6 +1,6 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
-var clickhouse = builder.AddClickHouse("clickhouse")
+var clickhouse = builder.AddClickHouse("clickhouse", imageTag: "latest")
                     .AddDatabase("default");
 
 builder.AddProject<Projects.ClickHouse_DemoApi>("api")

--- a/src/ClickHouse.Hosting/ClickHouse.Hosting.csproj
+++ b/src/ClickHouse.Hosting/ClickHouse.Hosting.csproj
@@ -14,7 +14,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/cristipufu/aspire-clickhouse-hosting</RepositoryUrl>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/src/ClickHouse.Hosting/ClickHouseBuilderExtensions.cs
+++ b/src/ClickHouse.Hosting/ClickHouseBuilderExtensions.cs
@@ -19,19 +19,21 @@ public static class ClickHouseBuilderExtensions
     /// <param name="userName">The parameter used to provide the user name for the ClickHouse resource. If <see langword="null"/> a default value will be used.</param>
     /// <param name="password">The parameter used to provide the administrator password for the ClickHouse resource. If <see langword="null"/> a random password will be generated.</param>
     /// <param name="port">The host port used when launching the container. If null a random port will be assigned.</param>
+    /// <param name="imageTag">An optional image tag referring to https://hub.docker.com/r/clickhouse/clickhouse-server/tags</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<ClickHouseServerResource> AddClickHouse(this IDistributedApplicationBuilder builder,
         string name,
         IResourceBuilder<ParameterResource>? userName = null,
         IResourceBuilder<ParameterResource>? password = null,
-        int? port = null)
+        int? port = null, 
+        string? imageTag = null)
     {
         var passwordParameter = password?.Resource ?? ParameterResourceBuilderExtensions.CreateDefaultPasswordParameter(builder, $"{name}-password");
 
         var server = new ClickHouseServerResource(name, userName?.Resource, passwordParameter);
         return builder.AddResource(server)
                       .WithEndpoint(port: port, targetPort: 8123, name: ClickHouseServerResource.PrimaryEndpointName) // HTTP default port is 8123.
-                      .WithImage(ClickHouseContainerImageTags.Image, ClickHouseContainerImageTags.Tag)
+                      .WithImage(ClickHouseContainerImageTags.Image, imageTag ?? ClickHouseContainerImageTags.Tag)
                       .WithImageRegistry(ClickHouseContainerImageTags.Registry)
                       .WithEnvironment(context =>
                       {

--- a/src/ClickHouse.Hosting/ClickHouseContainerImageTags.cs
+++ b/src/ClickHouse.Hosting/ClickHouseContainerImageTags.cs
@@ -7,5 +7,5 @@ internal static class ClickHouseContainerImageTags
 {
     public const string Registry = "docker.io";
     public const string Image = "clickhouse/clickhouse-server";
-    public const string Tag = "24.4";
+    public const string Tag = "25.6";
 }


### PR DESCRIPTION
Added imageTag parameter to AddClickhouse method for specifying newer/latest builds. 
Defaulted image tag to 25.6
Bumped version to 1.1
Updated README

I tested it on the playground. 